### PR TITLE
feat: handle gifs correctly

### DIFF
--- a/src/components/image.tsx
+++ b/src/components/image.tsx
@@ -25,11 +25,14 @@ export default function ({ src, ...props }: ImageProps) {
     return <img src={svg.svg?.dataURI ?? undefined} alt={props.alt} />
   }
 
-  return (
-    <GatsbyImage
-      image={image.childImageSharp?.gatsbyImageData}
-      objectFit="contain"
-      {...props}
-    />
-  )
+  const imageData = image.childImageSharp?.gatsbyImageData
+
+  if (imageData) {
+    return (
+      <GatsbyImage image={imageData} objectFit="contain" {...props} />
+    )
+  }
+
+  return <img src={image.publicURL ?? undefined} {...props} />
+
 }

--- a/src/hooks/useImageData.ts
+++ b/src/hooks/useImageData.ts
@@ -34,6 +34,7 @@ export default function useImageData(src: string): SvgOrImage {
         nonSvg: allFile(filter: { sourceInstanceName: { eq: "images" }, extension: { ne: "svg" } }) {
           nodes {
             relativePath
+            publicURL
             childImageSharp {
               gatsbyImageData
             }


### PR DESCRIPTION
Gatsby does not optimize GIFs (and maybe some other image types), so `image.childImageSharp` will be `undefined` in these cases. However, it will still set a `publicURL`, which can be used to show an unoptimized image that is the same regardless of screen size.